### PR TITLE
Consistent usage of file separator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.gradle
+/.idea
+/build
+*.iml
+*.ipr
+*.iws

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
+apply plugin: 'idea'
 
 version = '2.0.14'
 

--- a/src/main/java/com/crowdin/cli/BaseCli.java
+++ b/src/main/java/com/crowdin/cli/BaseCli.java
@@ -24,8 +24,6 @@ public class BaseCli {
 
     protected static final String OPTION_NAME_IDENTITY = "identity";
 
-    protected static final String PATH_SEPARATOR = (Utils.isWindows()) ? File.separator + File.separator : File.separator;
-
     protected static final ResourceBundle RESOURCE_BUNDLE = MessageSource.RESOURCE_BUNDLE;
 
     protected static final String STRING_PLUS = "+";

--- a/src/main/java/com/crowdin/cli/commands/Commands.java
+++ b/src/main/java/com/crowdin/cli/commands/Commands.java
@@ -446,17 +446,17 @@ public class Commands extends BaseCli {
                 } else {
                     fName = sourceFile.getName();
                 }
-                preservePath = preservePath + PATH_SEPARATOR + fName;
-                preservePath = preservePath.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
-                if (preservePath.startsWith(PATH_SEPARATOR)) {
-                    preservePath = preservePath.replaceFirst(PATH_SEPARATOR, "");
+                preservePath = preservePath + Utils.PATH_SEPARATOR + fName;
+                preservePath = preservePath.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
+                if (preservePath.startsWith(Utils.PATH_SEPARATOR)) {
+                    preservePath = preservePath.replaceFirst(Utils.PATH_SEPARATOR_REGEX, "");
                 }
                 CrowdinApiParametersBuilder parameters = new CrowdinApiParametersBuilder();
                 parameters.headers(HEADER_ACCEPT, HEADER_ACCAEPT_VALUE)
                         .headers(HEADER_CLI_VERSION, HEADER_CLI_VERSION_VALUE)
                         .headers(HEADER_JAVA_VERSION, HEADER_JAVA_VERSION_VALUE)
                         .headers(HEADER_USER_AGENT, HEADER_USER_AGENT_VALUE);
-                preservePath = preservePath.replaceAll(PATH_SEPARATOR, "/");
+                preservePath = preservePath.replaceAll(Utils.PATH_SEPARATOR_REGEX, "/");
                 if (this.branch != null && !this.branch.isEmpty()) {
                     parameters.branch(this.branch);
                 }
@@ -501,14 +501,14 @@ public class Commands extends BaseCli {
                     }
                     if (translationWithReplacedAsterisk != null) {
                         if (translationWithReplacedAsterisk.indexOf("\\") != -1) {
-                            translationWithReplacedAsterisk = translationWithReplacedAsterisk.replaceAll(PATH_SEPARATOR, "/");
+                            translationWithReplacedAsterisk = translationWithReplacedAsterisk.replaceAll(Utils.PATH_SEPARATOR_REGEX, "/");
                             translationWithReplacedAsterisk = translationWithReplacedAsterisk.replaceAll("/+", "/");
                         }
                         parameters.exportPatterns(preservePath, translationWithReplacedAsterisk);
                     } else {
                         String pattern = file.getTranslation();
                         if (pattern != null && pattern.indexOf("\\") != -1) {
-                            pattern = pattern.replaceAll(PATH_SEPARATOR, "/");
+                            pattern = pattern.replaceAll(Utils.PATH_SEPARATOR_REGEX, "/");
                             pattern = pattern.replaceAll("/+", "/");
                         }
                         parameters.exportPatterns(preservePath, pattern);
@@ -667,8 +667,8 @@ public class Commands extends BaseCli {
                         }
                         commonPath = (commonPath == null) ? "" : commonPath;
                         for (String translation : translations) {
-                            translation = PATH_SEPARATOR + translation;
-                            translation = translation.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+                            translation = Utils.PATH_SEPARATOR + translation;
+                            translation = translation.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
                             String mappedTranslations = translation;
                             if (Utils.isWindows() && translation.contains("\\")) {
                                 translation = translation.replaceAll("\\\\+", "/").replaceAll("  \\+", "/");
@@ -676,8 +676,8 @@ public class Commands extends BaseCli {
                             if (mapping != null && (mapping.get(translation) != null || mapping.get("/" + translation) != null)) {
                                 mappedTranslations = mapping.get(translation);
                             }
-                            mappedTranslations = propertiesBean.getBasePath() + PATH_SEPARATOR + mappedTranslations;
-                            mappedTranslations = mappedTranslations.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+                            mappedTranslations = propertiesBean.getBasePath() + Utils.PATH_SEPARATOR + mappedTranslations;
+                            mappedTranslations = mappedTranslations.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
                             translationFiles.add(new File(mappedTranslations));
                         }
                         for (File translationFile : translationFiles) {
@@ -705,14 +705,14 @@ public class Commands extends BaseCli {
                                     translationSrc = translationSrc.replaceFirst(commonPath, "");
                                 }
                                 if (Utils.isWindows() && translationSrc.contains("/")) {
-                                    translationSrc = translationSrc.replaceAll("/", PATH_SEPARATOR);
+                                    translationSrc = translationSrc.replaceAll("/", Utils.PATH_SEPARATOR_REGEX);
                                 }
                             }
                             if (branch != null) {
                                 parameters.branch(branch);
                             }
                             if (Utils.isWindows()) {
-                                translationSrc = translationSrc.replaceAll(PATH_SEPARATOR + "+", "/");
+                                translationSrc = translationSrc.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", "/");
                             }
                             if (translationSrc.startsWith("/")) {
                                 translationSrc = translationSrc.replaceFirst("/", "");
@@ -721,13 +721,13 @@ public class Commands extends BaseCli {
                             if (isDest) {
                                 translationSrc = file.getDest();
                                 if (!propertiesBean.getPreserveHierarchy()) {
-                                    if (translationSrc.lastIndexOf(PATH_SEPARATOR) != -1) {
-                                        translationSrc = translationSrc.substring(translationSrc.lastIndexOf(PATH_SEPARATOR));
+                                    if (translationSrc.lastIndexOf(Utils.PATH_SEPARATOR) != -1) {
+                                        translationSrc = translationSrc.substring(translationSrc.lastIndexOf(Utils.PATH_SEPARATOR));
                                     }
-                                    translationSrc = translationSrc.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+                                    translationSrc = translationSrc.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
                                 }
                                 if (Utils.isWindows()) {
-                                    translationSrc = translationSrc.replaceAll(PATH_SEPARATOR + "+", "/");
+                                    translationSrc = translationSrc.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", "/");
                                 }
                                 if (translationSrc.startsWith("/")) {
                                     translationSrc = translationSrc.replaceFirst("/", "");
@@ -969,10 +969,10 @@ public class Commands extends BaseCli {
             }
             String basePath = propertiesBean.getBasePath();
             String baseTempDir;
-            if (basePath.endsWith(File.separator)) {
+            if (basePath.endsWith(Utils.PATH_SEPARATOR)) {
                 baseTempDir = basePath + new Timestamp(System.currentTimeMillis()).getTime();
             } else {
-                baseTempDir = basePath + File.separator + new Timestamp(System.currentTimeMillis()).getTime();
+                baseTempDir = basePath + Utils.PATH_SEPARATOR + new Timestamp(System.currentTimeMillis()).getTime();
             }
             crowdinApiParametersBuilder.destinationFolder(basePath);
             try {
@@ -1000,8 +1000,8 @@ public class Commands extends BaseCli {
                 System.out.println(downloadResult);
             }
             File downloadedZipArchive;
-            if (propertiesBean.getBasePath() != null && !propertiesBean.getBasePath().endsWith(File.separator)) {
-                downloadedZipArchive = new File(propertiesBean.getBasePath() + File.separator + fileName);
+            if (propertiesBean.getBasePath() != null && !propertiesBean.getBasePath().endsWith(Utils.PATH_SEPARATOR)) {
+                downloadedZipArchive = new File(propertiesBean.getBasePath() + Utils.PATH_SEPARATOR + fileName);
             } else {
                 downloadedZipArchive = new File(propertiesBean.getBasePath() + fileName);
             }
@@ -1010,7 +1010,7 @@ public class Commands extends BaseCli {
                 List<String> downloadedFilesProc = new ArrayList<>();
                 for (String downloadedFile : downloadedFiles) {
                     if (Utils.isWindows()) {
-                        downloadedFile = downloadedFile.replaceAll(PATH_SEPARATOR + "+", "/");
+                        downloadedFile = downloadedFile.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", "/");
                     }
                     downloadedFilesProc.add(downloadedFile);
                 }
@@ -1020,10 +1020,11 @@ public class Commands extends BaseCli {
                 for (String translation : translations) {
                     translation = translation.replaceAll("/+", "/");
                     if (!files.contains(translation)) {
-                        if (translation.contains(PATH_SEPARATOR)) {
-                            translation = translation.replaceAll(PATH_SEPARATOR + "+", "/");
-                        } else if (translation.contains(File.separator)) {
-                            translation = translation.replaceAll(File.separator+File.separator, "/");
+                        //TODO: This usage is a bit unclear. Is the string supposed to be a regex or not?
+                        if (translation.contains(Utils.PATH_SEPARATOR_REGEX)) {
+                            translation = translation.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", "/");
+                        } else if (translation.contains(Utils.PATH_SEPARATOR)) {
+                            translation = translation.replaceAll(Utils.PATH_SEPARATOR_REGEX + Utils.PATH_SEPARATOR_REGEX, "/");
                         }
                         translation = translation.replaceAll("/+", "/");
                         files.add(translation);
@@ -1082,7 +1083,7 @@ public class Commands extends BaseCli {
                 if (branch != null) {
                     for (String file : files) {
                         if (file.startsWith(branch) || file.startsWith("/" + branch)) {
-                            result.add(PATH_SEPARATOR + file);
+                            result.add(Utils.PATH_SEPARATOR + file);
                         }
                     }
                 } else {
@@ -1167,20 +1168,20 @@ public class Commands extends BaseCli {
                         path = path.replaceFirst("/" + commonPath, "");
                     }
                     if (Utils.isWindows() && path.contains("/")) {
-                        path = path.replaceAll("/", PATH_SEPARATOR);
+                        path = path.replaceAll("/", Utils.PATH_SEPARATOR_REGEX);
                     }
-                    if (path.startsWith(PATH_SEPARATOR)) {
-                        path = path.replaceFirst(PATH_SEPARATOR, "");
+                    if (path.startsWith(Utils.PATH_SEPARATOR)) {
+                        path = path.replaceFirst(Utils.PATH_SEPARATOR_REGEX, "");
                     }
-                    String[] nodes = path.split(PATH_SEPARATOR);
+                    String[] nodes = path.split(Utils.PATH_SEPARATOR_REGEX);
                     for (String node : nodes) {
                         if (node != null && !node.isEmpty()) {
-                            f.append(node).append(PATH_SEPARATOR);
-                            String preservePath = propertiesBean.getBasePath() + PATH_SEPARATOR + commonPath + PATH_SEPARATOR +  f;
-                            preservePath = preservePath.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+                            f.append(node).append(Utils.PATH_SEPARATOR);
+                            String preservePath = propertiesBean.getBasePath() + Utils.PATH_SEPARATOR + commonPath + Utils.PATH_SEPARATOR +  f;
+                            preservePath = preservePath.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
                             File treeFile = new File(preservePath);
                             if (treeFile.isDirectory()) {
-                                resultFiles.append(node).append(PATH_SEPARATOR);
+                                resultFiles.append(node).append(Utils.PATH_SEPARATOR);
                             } else {
                                 resultFiles.append(node);
                             }
@@ -1200,9 +1201,9 @@ public class Commands extends BaseCli {
                 if (propertiesBean.getPreserveHierarchy()) {
                     src = Utils.replaceBasePath(file, propertiesBean);
                     if (branch != null && !branch.isEmpty()) {
-                        src = PATH_SEPARATOR + branch + PATH_SEPARATOR + src;
+                        src = Utils.PATH_SEPARATOR + branch + Utils.PATH_SEPARATOR + src;
                     }
-                    src = src.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+                    src = src.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
                     System.out.println(src);
                 } else {
                     src = Utils.replaceBasePath(file, propertiesBean);
@@ -1222,12 +1223,12 @@ public class Commands extends BaseCli {
                         src = src.replaceFirst("/" + commonPath, "");
                     }
                     if (Utils.isWindows() && src.contains("/")) {
-                        src = src.replaceAll("/", PATH_SEPARATOR);
+                        src = src.replaceAll("/", Utils.PATH_SEPARATOR_REGEX);
                     }
                     if (branch != null && !branch.isEmpty()) {
-                        src = branch + File.separator + src;
+                        src = branch + Utils.PATH_SEPARATOR + src;
                     }
-                    src = src.replaceAll(File.separator + "+", File.separator);
+                    src = src.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
                     System.out.println(src);
                 }
             }
@@ -1243,7 +1244,7 @@ public class Commands extends BaseCli {
         common = mappingTranslations.values().toArray(common);
         commonPath = Utils.commonPath(common);
         for (Map.Entry<String, String> mappingTranslation : mappingTranslations.entrySet()) {
-            String s = mappingTranslation.getValue().replaceAll("/+", PATH_SEPARATOR);
+            String s = mappingTranslation.getValue().replaceAll("/+", Utils.PATH_SEPARATOR_REGEX);
             if (!propertiesBean.getPreserveHierarchy()) {
                 if (s.startsWith(commonPath)) {
                     s = s.replaceFirst(commonPath, "");
@@ -1268,7 +1269,7 @@ public class Commands extends BaseCli {
         List<String> files = this.list(PROJECT, "project");
         List<String> filesWin = new ArrayList<>();
         for (String file : files) {
-            file = file.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+            file = file.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
             filesWin.add(file);
         }
         commandUtils.sortFilesName(files);
@@ -1279,7 +1280,7 @@ public class Commands extends BaseCli {
             drawTree.draw(filesWin, ident);
         } else {
             for (String file : files) {
-                System.out.println(file.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR));
+                System.out.println(file.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX));
             }
         }
     }

--- a/src/main/java/com/crowdin/cli/properties/CliProperties.java
+++ b/src/main/java/com/crowdin/cli/properties/CliProperties.java
@@ -72,8 +72,6 @@ public class CliProperties {
 
     private static final String SCHEME = "scheme";
 
-    private static final String PATH_SEPARATOR = (Utils.isWindows()) ? File.separator + File.separator : File.separator;
-
     public PropertiesBean loadProperties(HashMap<String, Object> properties) {
         if (properties == null || properties.isEmpty()) {
             System.out.println(RESOURCE_BUNDLE.getString("error_empty_properties_file"));
@@ -266,7 +264,7 @@ public class CliProperties {
                     hasError = true;
                 }
                 if (Utils.isWindows() && file.getSource() != null && file.getSource().contains("/")) {
-                    file.setSource(file.getSource().replaceAll("/+", PATH_SEPARATOR));
+                    file.setSource(file.getSource().replaceAll("/+", Utils.PATH_SEPARATOR_REGEX));
                 }
                 //Translation
                 if (file.getTranslation() == null || file.getTranslation().isEmpty()) {
@@ -278,18 +276,18 @@ public class CliProperties {
                     System.out.println("When using `**` in 'translation' pattern it will always contain sub-path from 'source' for certain file.");
                     hasError = true;
                 }
-                if (file.getTranslation() != null && !file.getTranslation().startsWith(PATH_SEPARATOR)) {
+                if (file.getTranslation() != null && !file.getTranslation().startsWith(Utils.PATH_SEPARATOR)) {
                     if (file.getTranslation().contains("%language%")
                             || file.getTranslation().contains("%two_letters_code%")
                             || file.getTranslation().contains("%three_letters_code%")
                             || file.getTranslation().contains("%locale%")) {
-                        String translation = PATH_SEPARATOR + file.getTranslation();
-                        translation = translation.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+                        String translation = Utils.PATH_SEPARATOR + file.getTranslation();
+                        translation = translation.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
                         file.setTranslation(translation);
                     }
                 }
                 if (Utils.isWindows() && file.getTranslation() != null && file.getTranslation().contains("/")) {
-                    file.setTranslation(file.getTranslation().replaceAll("/+", PATH_SEPARATOR));
+                    file.setTranslation(file.getTranslation().replaceAll("/+", Utils.PATH_SEPARATOR_REGEX));
                 }
                 //Ignore
                 if (file.getIgnore() == null || file.getIgnore().isEmpty()) {
@@ -298,7 +296,7 @@ public class CliProperties {
                         List<String> ignores = new ArrayList<>();
                         for (String ignore : file.getIgnore()) {
                             if (ignore.contains("/")) {
-                                ignores.add(ignore.replaceAll("/+", PATH_SEPARATOR));
+                                ignores.add(ignore.replaceAll("/+", Utils.PATH_SEPARATOR_REGEX));
                             } else {
                                 ignores.add(ignore);
                             }

--- a/src/main/java/com/crowdin/cli/properties/PropertiesBean.java
+++ b/src/main/java/com/crowdin/cli/properties/PropertiesBean.java
@@ -1,5 +1,7 @@
 package com.crowdin.cli.properties;
 
+import com.crowdin.cli.utils.Utils;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,8 +62,8 @@ public class PropertiesBean {
     }
 
     public void setBasePath(String basePath) {
-        if (basePath != null && !basePath.isEmpty() && !basePath.endsWith(File.separator) && !".".equals(basePath)) {
-            this.basePath = basePath + File.separator;
+        if (basePath != null && !basePath.isEmpty() && !basePath.endsWith(Utils.PATH_SEPARATOR) && !".".equals(basePath)) {
+            this.basePath = basePath + Utils.PATH_SEPARATOR;
         } else {
             this.basePath = basePath;
         }

--- a/src/main/java/com/crowdin/cli/properties/helper/FileHelper.java
+++ b/src/main/java/com/crowdin/cli/properties/helper/FileHelper.java
@@ -17,8 +17,6 @@ import org.apache.commons.io.filefilter.RegexFileFilter;
  */
 public class FileHelper {
 
-    private static final String FOLDER_SEPARATOR = (Utils.isWindows()) ? File.separator + File.separator : File.separator;
-
     private static final String DOUBLED_ASTERISK = "**";
 
     private static final String REGEX = "regex";
@@ -52,16 +50,16 @@ public class FileHelper {
         if (file != null) {
             String pattern = file.getSource();
             if (propertiesBean != null && propertiesBean.getBasePath() != null) {
-                if (!propertiesBean.getBasePath().trim().endsWith(FOLDER_SEPARATOR) && !file.getSource().trim().startsWith(FOLDER_SEPARATOR)) {
-                    pattern = propertiesBean.getBasePath() + FOLDER_SEPARATOR + file.getSource();
+                if (!propertiesBean.getBasePath().trim().endsWith(Utils.PATH_SEPARATOR) && !file.getSource().trim().startsWith(Utils.PATH_SEPARATOR)) {
+                    pattern = propertiesBean.getBasePath() + Utils.PATH_SEPARATOR + file.getSource();
                 } else {
                     pattern = propertiesBean.getBasePath().trim() + file.getSource().trim();
-                    pattern = pattern.replaceAll(FOLDER_SEPARATOR + "+", FOLDER_SEPARATOR);
+                    pattern = pattern.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
                 }
             }
             pattern = pattern.replaceAll("\\\\+", "\\\\");
             pattern = pattern.replaceAll("/+", "/");
-            String[] nodes = pattern.split(FOLDER_SEPARATOR);
+            String[] nodes = pattern.split(Utils.PATH_SEPARATOR_REGEX);
             StringBuilder resultPath = new StringBuilder();
             for (String node : nodes) {
                 if (!node.isEmpty()) {
@@ -92,14 +90,14 @@ public class FileHelper {
                 for (String pattern : ignores) {
                     List<File> resultListTemp = new ArrayList<>();
                     if (propertiesBean != null && propertiesBean.getBasePath() != null) {
-                        if (!propertiesBean.getBasePath().trim().endsWith(File.separator) && !pattern.trim().startsWith(File.separator)) {
-                            pattern = propertiesBean.getBasePath() + File.separator + pattern;
+                        if (!propertiesBean.getBasePath().trim().endsWith(Utils.PATH_SEPARATOR) && !pattern.trim().startsWith(Utils.PATH_SEPARATOR)) {
+                            pattern = propertiesBean.getBasePath() + Utils.PATH_SEPARATOR + pattern;
                         } else {
                             pattern = propertiesBean.getBasePath().trim() + pattern.trim();
-                            pattern = pattern.replace(File.separator + File.separator, File.separator);
+                            pattern = pattern.replace(Utils.PATH_SEPARATOR_REGEX + Utils.PATH_SEPARATOR_REGEX, Utils.PATH_SEPARATOR_REGEX);
                         }
                     }
-                    String[] nodes = pattern.split(FOLDER_SEPARATOR);
+                    String[] nodes = pattern.split(Utils.PATH_SEPARATOR_REGEX);
                     StringBuilder resultPath = new StringBuilder();
                     for (String node : nodes) {
                         if (!node.isEmpty()) {
@@ -189,7 +187,7 @@ public class FileHelper {
             resultList.clear();
             for (File file : tmpResultList) {
                 StringBuilder absolutePath = new StringBuilder(file.getAbsolutePath());
-                absolutePath.append(FOLDER_SEPARATOR);
+                absolutePath.append(Utils.PATH_SEPARATOR);
                 if (null != patternName) {
                     if (DOUBLED_ASTERISK.equals(patternName)) {
                         List<File> files = getlistDirectory(absolutePath.toString());
@@ -220,9 +218,9 @@ public class FileHelper {
             }
         } else {
             if (node != null && node.endsWith(":")) {
-                resultPath.append(node + FOLDER_SEPARATOR);
+                resultPath.append(node + Utils.PATH_SEPARATOR);
             } else {
-                resultPath.append(FOLDER_SEPARATOR);
+                resultPath.append(Utils.PATH_SEPARATOR);
             }
             if (null != patternName) {
                 if (DOUBLED_ASTERISK.equals(patternName)) {
@@ -230,7 +228,7 @@ public class FileHelper {
                     if (!files.isEmpty()) {
                         resultList.clear();
                         for (File f : files) {
-                            File tmpF = new File(resultPath.toString() + FOLDER_SEPARATOR + f.getName());
+                            File tmpF = new File(resultPath.toString(), f.getName());
                             if (tmpF.isDirectory()) {
                                 resultList.add(tmpF);
                             }

--- a/src/main/java/com/crowdin/cli/utils/CommandUtils.java
+++ b/src/main/java/com/crowdin/cli/utils/CommandUtils.java
@@ -58,8 +58,8 @@ public class CommandUtils extends BaseCli {
         }
         String userHome = System.getProperty(USER_HOME);
         if (userHome != null && !userHome.isEmpty()) {
-            userHome = userHome + PATH_SEPARATOR + fileName;
-            userHome = userHome.replaceAll(PATH_SEPARATOR + STRING_PLUS, PATH_SEPARATOR);
+            userHome = userHome + Utils.PATH_SEPARATOR + fileName;
+            userHome = userHome.replaceAll(Utils.PATH_SEPARATOR_REGEX + STRING_PLUS, Utils.PATH_SEPARATOR_REGEX);
             identity = new File(userHome);
         } else {
             identity = new File(fileName);
@@ -113,7 +113,7 @@ public class CommandUtils extends BaseCli {
                 replacement = sources;
             }
             translations = translations.replace("**", replacement);
-            translations = translations.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+            translations = translations.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
         }
         return translations;
     }
@@ -175,8 +175,8 @@ public class CommandUtils extends BaseCli {
         StringBuilder dirs = new StringBuilder();
         StringBuilder resultDirs = new StringBuilder();
         String filePath = Utils.replaceBasePath(sourcePath, propertiesBean);
-        if (filePath.startsWith(PATH_SEPARATOR)) {
-            filePath = filePath.replaceFirst(PATH_SEPARATOR, "");
+        if (filePath.startsWith(Utils.PATH_SEPARATOR)) {
+            filePath = filePath.replaceFirst(Utils.PATH_SEPARATOR_REGEX, "");
         }
         if (!propertiesBean.getPreserveHierarchy()) {
             if (Utils.isWindows()) {
@@ -195,13 +195,13 @@ public class CommandUtils extends BaseCli {
                 filePath = filePath.replaceFirst("/" + commonPath, "");
             }
             if (Utils.isWindows() && filePath.contains("/")) {
-                filePath = filePath.replaceAll("/", PATH_SEPARATOR);
+                filePath = filePath.replaceAll("/", Utils.PATH_SEPARATOR_REGEX);
             }
         }
         if (file.getDest() != null && !file.getDest().isEmpty() && !this.isSourceContainsPattern(file.getSource())) {
             if (propertiesBean.getPreserveHierarchy()) {
-                if (file.getDest().contains(PATH_SEPARATOR)) {
-                    nodes = file.getDest().split(PATH_SEPARATOR);
+                if (file.getDest().contains(Utils.PATH_SEPARATOR)) {
+                    nodes = file.getDest().split(Utils.PATH_SEPARATOR_REGEX);
                 } else if (file.getDest().contains("\\")) {
                     nodes = file.getDest().split("\\\\");
                 } else {
@@ -209,8 +209,8 @@ public class CommandUtils extends BaseCli {
                 }
             }
         } else {
-            if (filePath.contains(PATH_SEPARATOR)) {
-                nodes = filePath.split(PATH_SEPARATOR);
+            if (filePath.contains(Utils.PATH_SEPARATOR)) {
+                nodes = filePath.split(Utils.PATH_SEPARATOR_REGEX);
             } else if (filePath.contains("\\")) {
                 nodes = filePath.split("\\\\");
             } else {
@@ -224,13 +224,13 @@ public class CommandUtils extends BaseCli {
                         if (dirs.length() == 0) {
                             dirs.append(node);
                         } else {
-                            dirs.append(PATH_SEPARATOR)
+                            dirs.append(Utils.PATH_SEPARATOR)
                                     .append(node);
                         }
                         if (resultDirs.length() == 0) {
                             resultDirs.append(node);
                         } else {
-                            resultDirs.append(PATH_SEPARATOR)
+                            resultDirs.append(Utils.PATH_SEPARATOR)
                                     .append(node);
                         }
                         if (directories.contains(resultDirs.toString())) {
@@ -241,8 +241,8 @@ public class CommandUtils extends BaseCli {
                         }
                         parametersBuilder.json();
                         String directoryName = resultDirs.toString();
-                        if (directoryName.indexOf(PATH_SEPARATOR) != -1) {
-                            directoryName = directoryName.replaceAll(PATH_SEPARATOR, "/");
+                        if (directoryName.indexOf(Utils.PATH_SEPARATOR) != -1) {
+                            directoryName = directoryName.replaceAll(Utils.PATH_SEPARATOR_REGEX, "/");
                             directoryName = directoryName.replaceAll("/+","/");
                         }
                         parametersBuilder.name(directoryName);
@@ -404,15 +404,15 @@ public class CommandUtils extends BaseCli {
                     }
                 }
             }
-            String key = baseTempDir + PATH_SEPARATOR + preservedKey;
-            key = key.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
-            String value = propertiesBean.getBasePath() + PATH_SEPARATOR + entry.getValue();
-            value = value.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+            String key = baseTempDir + Utils.PATH_SEPARATOR + preservedKey;
+            key = key.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
+            String value = propertiesBean.getBasePath() + Utils.PATH_SEPARATOR + entry.getValue();
+            value = value.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
             if (Utils.isWindows()) {
-                key = key.replaceAll("/+", PATH_SEPARATOR);
-                key = key.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
-                value = value.replaceAll("/+", PATH_SEPARATOR);
-                value = value.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+                key = key.replaceAll("/+", Utils.PATH_SEPARATOR_REGEX);
+                key = key.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
+                value = value.replaceAll("/+", Utils.PATH_SEPARATOR_REGEX);
+                value = value.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
             }
             if (!key.equals(value)) {
                 File oldFile = new File(key);
@@ -482,8 +482,8 @@ public class CommandUtils extends BaseCli {
         for (Map.Entry<String, String> extractingMappingFile : mapping.entrySet()) {
             String k = extractingMappingFile.getKey();
             k = k.replaceAll("/+", "/");
-            if (k.indexOf(PATH_SEPARATOR) != -1) {
-                k = k.replaceAll(PATH_SEPARATOR, "/");
+            if (k.indexOf(Utils.PATH_SEPARATOR) != -1) {
+                k = k.replaceAll(Utils.PATH_SEPARATOR_REGEX, "/");
                 k = k.replaceAll("/+", "/");
             }
             if (k.indexOf("/") != -1) {
@@ -503,8 +503,8 @@ public class CommandUtils extends BaseCli {
                 k = k.replaceFirst("/", "");
             }
             String v = extractingMappingFile.getValue();
-            if (v.indexOf(PATH_SEPARATOR) != -1) {
-                v = v.replaceAll(PATH_SEPARATOR, "/");
+            if (v.indexOf(Utils.PATH_SEPARATOR) != -1) {
+                v = v.replaceAll(Utils.PATH_SEPARATOR_REGEX, "/");
                 v = v.replaceAll("/+", "/");
             }
             if (extractingFiles.contains(k) || extractingFiles.contains("/" + k)) {
@@ -541,10 +541,10 @@ public class CommandUtils extends BaseCli {
             ZipEntry ze = (ZipEntry) zipEntries.nextElement();
             if (!ze.isDirectory()) {
                 String fname = ze.getName();
-                if (!fname.startsWith(PATH_SEPARATOR)) {
-                    fname = PATH_SEPARATOR + fname;
+                if (!fname.startsWith(Utils.PATH_SEPARATOR)) {
+                    fname = Utils.PATH_SEPARATOR + fname;
                     if (Utils.isWindows()) {
-                        fname = fname.replaceAll(PATH_SEPARATOR + "+", "/");
+                        fname = fname.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", "/");
                     }
                 }
                 downloadedFiles.add(fname);
@@ -702,8 +702,8 @@ public class CommandUtils extends BaseCli {
                                 String temporaryTranslationsMapping = translationsMapping;
                                 String fileParent = new File(f.getParent()).getAbsolutePath();
                                 fileParent = Utils.replaceBasePath(fileParent, propertiesBean);
-                                if (fileParent.startsWith(PATH_SEPARATOR)) {
-                                    fileParent = fileParent.replaceFirst(PATH_SEPARATOR, "");
+                                if (fileParent.startsWith(Utils.PATH_SEPARATOR)) {
+                                    fileParent = fileParent.replaceFirst(Utils.PATH_SEPARATOR_REGEX, "");
                                 }
                                 temporaryTranslation = temporaryTranslation.replace(PLACEHOLDER_ORIGINAL_FILE_NAME, f.getName());
                                 temporaryTranslation = temporaryTranslation.replace(PLACEHOLDER_FILE_NAME, FilenameUtils.removeExtension(f.getName()));
@@ -717,7 +717,7 @@ public class CommandUtils extends BaseCli {
                                 temporaryTranslation = temporaryTranslation.replace(PLACEHOLDER_OSX_CODE, Utils.getOsXLocaleCode(languageInfo.getString("crowdin_code")));
                                 String k = this.replaceDoubleAsteriskInTranslation(temporaryTranslation, f.getAbsolutePath(), file.getSource(), propertiesBean);
                                 String v = this.replaceDoubleAsteriskInTranslation(temporaryTranslationsMapping, f.getAbsolutePath(), file.getSource(), propertiesBean);
-                                k = k.replaceAll(PATH_SEPARATOR, "/");
+                                k = k.replaceAll(Utils.PATH_SEPARATOR_REGEX, "/");
                                 k = k.replaceAll("/+", "/");
                                 mapping.put(k, v);
                             }
@@ -725,7 +725,7 @@ public class CommandUtils extends BaseCli {
                             if (this.getSourcesWithoutIgnores(file, propertiesBean) != null && this.getSourcesWithoutIgnores(file, propertiesBean).size() > 0) {
                                 String k = this.replaceDoubleAsteriskInTranslation(translationsBase, this.getSourcesWithoutIgnores(file, propertiesBean).get(0), file.getSource(), propertiesBean);
                                 String v = this.replaceDoubleAsteriskInTranslation(translationsMapping, this.getSourcesWithoutIgnores(file, propertiesBean).get(0), file.getSource(), propertiesBean);
-                                k = k.replaceAll(PATH_SEPARATOR, "/");
+                                k = k.replaceAll(Utils.PATH_SEPARATOR_REGEX, "/");
                                 k = k.replaceAll("/+", "/");
                                 mapping.put(k, v);
                             }
@@ -789,11 +789,11 @@ public class CommandUtils extends BaseCli {
                             String fileParent = new File(f.getParent()).getAbsolutePath();
                             if (!propertiesBean.getPreserveHierarchy() && "download".equals(command)) {
                                 if (Utils.isWindows()) {
-                                    fileParent = fileParent.replaceAll(PATH_SEPARATOR + "+", "/");
-                                    commonPath = commonPath.replaceAll(PATH_SEPARATOR + "+", "/");
+                                    fileParent = fileParent.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", "/");
+                                    commonPath = commonPath.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", "/");
                                     fileParent = fileParent.replaceFirst(commonPath, "");
-                                    fileParent = fileParent.replaceAll("/+", PATH_SEPARATOR);
-                                    commonPath = commonPath.replaceAll("/+", PATH_SEPARATOR);
+                                    fileParent = fileParent.replaceAll("/+", Utils.PATH_SEPARATOR_REGEX);
+                                    commonPath = commonPath.replaceAll("/+", Utils.PATH_SEPARATOR_REGEX);
                                 } else {
                                     fileParent = Utils.replaceBasePath(fileParent, propertiesBean);
                                 }
@@ -889,7 +889,7 @@ public class CommandUtils extends BaseCli {
     public List<String> projectList(JSONArray files, String path) {
         List<String> result = new ArrayList<>();
         if (path == null) {
-            path = PATH_SEPARATOR;
+            path = Utils.PATH_SEPARATOR;
         }
         if (files != null) {
             String s = path;
@@ -899,8 +899,8 @@ public class CommandUtils extends BaseCli {
                     path = s;
                 }
                 if (file != null && file.get("node_type") != null && ("branch".equals(file.get("node_type")) || "directory".equals(file.get("node_type")))) {
-                    path += PATH_SEPARATOR + file.get("name").toString() + PATH_SEPARATOR;
-                    path = path.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+                    path += Utils.PATH_SEPARATOR + file.get("name").toString() + Utils.PATH_SEPARATOR;
+                    path = path.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
                     result.addAll(projectList(file.getJSONArray("files"), path));
                     path = "";
                 } else if (file != null && file.get("node_type") != null && "file".equals(file.get("node_type"))) {
@@ -954,8 +954,8 @@ public class CommandUtils extends BaseCli {
             }
         } else if (configurationFile != null && configurationFile.isFile()) {
             basePath = (basePath == null) ? "" : basePath;
-            result =  Paths.get(configurationFile.getAbsolutePath()).getParent() + PATH_SEPARATOR + basePath;
-            result = result.replaceAll(PATH_SEPARATOR + "+",  PATH_SEPARATOR);
+            result =  Paths.get(configurationFile.getAbsolutePath()).getParent() + Utils.PATH_SEPARATOR + basePath;
+            result = result.replaceAll(Utils.PATH_SEPARATOR_REGEX + "+", Utils.PATH_SEPARATOR_REGEX);
         }
         return result;
     }
@@ -964,27 +964,27 @@ public class CommandUtils extends BaseCli {
         String result = "";
         if (sources.size() == 1) {
             result = sources.get(0);
-            if (result.contains(PATH_SEPARATOR)) {
-                result = result.substring(0, result.lastIndexOf(PATH_SEPARATOR));
+            if (result.contains(Utils.PATH_SEPARATOR)) {
+                result = result.substring(0, result.lastIndexOf(Utils.PATH_SEPARATOR));
             } else if (Utils.isWindows() && result.contains("/")) {
                 result = result.substring(0, result.lastIndexOf("/"));
             } else if (result.contains("\\")) {
                 result = result.substring(0, result.lastIndexOf("\\"));
             }
             result = Utils.replaceBasePath(result, propertiesBean);
-            if (result.startsWith(PATH_SEPARATOR)) {
-                result = result.replaceFirst(PATH_SEPARATOR, "");
+            if (result.startsWith(Utils.PATH_SEPARATOR)) {
+                result = result.replaceFirst(Utils.PATH_SEPARATOR_REGEX, "");
             }
         } else if (sources.size() > 1) {
             String[] common = new String[sources.size()];
             common = sources.toArray(common);
             result = Utils.commonPath(common);
             result = Utils.replaceBasePath(result, propertiesBean);
-            if (result.startsWith(PATH_SEPARATOR)) {
-                result = result.replaceFirst(PATH_SEPARATOR, "");
+            if (result.startsWith(Utils.PATH_SEPARATOR)) {
+                result = result.replaceFirst(Utils.PATH_SEPARATOR_REGEX, "");
             }
             if (Utils.isWindows() && result.contains("\\")) {
-                result = result.replaceFirst("\\\\", PATH_SEPARATOR);
+                result = result.replaceFirst("\\\\", Utils.PATH_SEPARATOR_REGEX);
             }
         }
         return result;

--- a/src/main/java/com/crowdin/cli/utils/Utils.java
+++ b/src/main/java/com/crowdin/cli/utils/Utils.java
@@ -4,6 +4,7 @@ import com.crowdin.cli.properties.PropertiesBean;
 import org.apache.commons.lang3.SystemUtils;
 
 import java.io.InputStream;
+import java.nio.file.FileSystems;
 import java.util.Properties;
 import java.util.ResourceBundle;
 
@@ -21,8 +22,16 @@ public class Utils {
     private static final String PROPERTIES_FILE = "/crowdin.properties";
 
     private static final String USER_AGENT = "application.user_agent";
-    
-    private static final String PATH_SEPARATOR = (Utils.isWindows()) ? "\\\\" : "/";
+
+    /**
+     * Path separator for use when concatenating or using non-regex find/replace methods.
+     */
+    public static final String PATH_SEPARATOR = FileSystems.getDefault().getSeparator();
+
+    /**
+     * Path separator for use in regex patterns, or in regex replacements, which use the same escaping.
+     */
+    public static final String PATH_SEPARATOR_REGEX = "\\".equals(PATH_SEPARATOR) ? "\\\\" : PATH_SEPARATOR;
 
     private static final ResourceBundle RESOURCE_BUNDLE = MessageSource.RESOURCE_BUNDLE;
 
@@ -109,12 +118,12 @@ public class Utils {
         }
         String result;
         if (propertiesBean !=  null && propertiesBean.getBasePath() != null && !propertiesBean.getBasePath().isEmpty()) {
-            path = path.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+            path = path.replaceAll(PATH_SEPARATOR_REGEX + "+", PATH_SEPARATOR_REGEX);
             result = path.replace(propertiesBean.getBasePath(), PATH_SEPARATOR);
         } else {
             result = PATH_SEPARATOR;
         }
-        result = result.replaceAll(PATH_SEPARATOR + "+", PATH_SEPARATOR);
+        result = result.replaceAll(PATH_SEPARATOR_REGEX + "+", PATH_SEPARATOR_REGEX);
         return result;
     }
 
@@ -147,7 +156,7 @@ public class Utils {
             String[] winPath = new String[paths.length];
             for (int i=0; i<paths.length; i++) {
                 if (paths[i].contains("/")) {
-                    winPath[i] = paths[i].replaceAll("/+", PATH_SEPARATOR);
+                    winPath[i] = paths[i].replaceAll("/+", PATH_SEPARATOR_REGEX);
                 } else {
                     winPath[i] = paths[i];
                 }
@@ -164,7 +173,7 @@ public class Utils {
         } else if (paths.length > 1) {
             String[][] folders = new String[paths.length][];
             for(int i = 0; i < paths.length; i++){
-                folders[i] = paths[i].split(PATH_SEPARATOR);
+                folders[i] = paths[i].split(PATH_SEPARATOR_REGEX);
             }
             for(int j = 0; j < folders[0].length; j++){
                 String thisFolder = folders[0][j];

--- a/src/main/java/com/crowdin/cli/utils/tree/DrawTree.java
+++ b/src/main/java/com/crowdin/cli/utils/tree/DrawTree.java
@@ -10,8 +10,6 @@ import java.util.List;
  */
 public class DrawTree {
 
-    private static final String PATH_SEPARATOR = (Utils.isWindows()) ? File.separator + File.separator : File.separator;
-
     public void draw(List<String> l, int ident) {
 
         Tree<String> top = new Tree<>(".");
@@ -19,7 +17,7 @@ public class DrawTree {
 
         for (String tree : l) {
             Tree<String> root = current;
-            for (String data : tree.split(PATH_SEPARATOR)) {
+            for (String data : tree.split(Utils.PATH_SEPARATOR_REGEX)) {
                 current = current.child(data);
             }
             current = root;


### PR DESCRIPTION
File.separator had a utility constant defined in multiple modules and
usage was inconsistent.

I have split it into the two usage types - the ones which are dealing
with file paths and the ones which are dealing with regex patterns.
Usages have been made consistent with the type of usage, but this
requires a good review of the code to make sure my interpretation of
each usage is correct. Some of the usages are ambiguous, which I have
left comments on.

(The pull request also adds .gitignore and other stuff to create an
IDEA project from the Gradle project.)